### PR TITLE
22 verifier que la premiere commande entree par lutilisateur soit pass

### DIFF
--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -159,13 +159,6 @@ int main(int argc, char **argv)
                         buffer[valread] = 0;
                         std::string *tmp = split(buffer, "\n");
                         std::string *all = split(*tmp, "\r");
-                        int j = 0;
-                        int u = 0;
-                        while (all[u].empty() != true && all[u][j] != 0)
-                        {
-                            DBG(all[u][j])
-                            j++;
-                        }
                         for (int x = 0; x < 5; x++)
                         {
                             std::string *value = split(all[x], " ");

--- a/srcs/users.cpp
+++ b/srcs/users.cpp
@@ -8,6 +8,7 @@ users   *new_user(int user_id, std::string nickname, std::string username)
     new_user->nickname = nickname;
     new_user->username = username;
     new_user->authentificate = false;
+    new_user->connected = false;
     new_user->next = NULL;
     return (new_user);
 }

--- a/srcs/users.hpp
+++ b/srcs/users.hpp
@@ -8,6 +8,7 @@ struct users {
     std::string     nickname;
     std::string     username;
     bool            authentificate;
+    bool            connected;
     struct users    *next;
 };
 

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -9,6 +9,12 @@ std::string *split(std::string to_split, std::string split_at)
     while (i < to_split.size())
     {
         pos = to_split.find(split_at);
+        if (pos > to_split.size())
+        {
+            token[i] = to_split.substr(0, to_split.size());
+            to_split.erase(0, to_split.size());
+            break ;
+        }
         token[i] = to_split.substr(0, pos);
         to_split.erase(0, pos + split_at.length());
         i++;

--- a/srcs/utils.hpp
+++ b/srcs/utils.hpp
@@ -3,6 +3,13 @@
 
 #include <iostream>
 
+struct server
+{
+    int fd;
+    char *pw;
+    int port;
+};
+
 std::string *split(std::string to_split, std::string split_at);
 
 #endif


### PR DESCRIPTION
Vérification que la première commande à utiliser pour le client est 'PASS' suivi du password du serveur.
Modification du split : lorsqu'il n'y a plus de séparateur dans la string à split, find() renvoie une pos indéfinie ce qui posait problème pour le erase.

Problème sur le split lorsqu'il y a deux séparateurs d'afilée dans la string à split

