### PR TITLE
fix issues #33/#35 & command KILL/OPER wip

### DIFF
--- a/srcs/channels.hpp
+++ b/srcs/channels.hpp
@@ -9,7 +9,7 @@ struct channel
 {
      std::string	name;
      std::string	topic;
-     int			users_id[100];			// Changer en liste d'ids des users
+     int			users_id[100];
      int			nb_users;
 	struct channel	*next;
 };
@@ -19,6 +19,6 @@ channel*	add_new_channel(channel *channels, channel *new_channel);
 bool		channel_exists(std::string name, channel *channels);
 channel*	find_channel(std::string name, channel *channels);
 void		display_channel_users(channel *channel);
-int         find_channel_user(channel *chan, users *user);
+int       find_channel_user(channel *chan, users *user);
 
 #endif

--- a/srcs/check.cpp
+++ b/srcs/check.cpp
@@ -61,3 +61,13 @@ void    check_password(users *all_users, pollfd *fds, std::string *value, char *
         send(fds[i].fd, "Password OK\n", strlen("Password OK\n"), 0);
     }
 }
+
+bool    is_banned_nickname(std::string nickname, std::vector<std::string> unavailable_nicks)
+{
+    for (unsigned int i = 0; i < unavailable_nicks.size(); i++)
+    {
+        if (unavailable_nicks[i] == nickname)
+            return (true);
+    }
+    return (false);
+}

--- a/srcs/check.hpp
+++ b/srcs/check.hpp
@@ -7,9 +7,11 @@
 
 #include "response.hpp"
 #include "users.hpp"
+#include <vector>
 
 bool    only_digits(char *str);
 int     check_args(int argc, char **argv);
 void    check_password(users *all_users, pollfd *fds, std::string *value, char *password, unsigned int i);
+bool    is_banned_nickname(std::string nickname, std::vector<std::string> unavailable_nicks);
 
 #endif

--- a/srcs/response.cpp
+++ b/srcs/response.cpp
@@ -150,3 +150,10 @@ void    send_no_privileges(int socket)
     send(socket, message.c_str(), message.length(), 0);
 }
 
+void    send_youre_oper(int socket)
+{
+    std::string message = ":127.0.0.1 381 RPL_YOUREOPER :You are now an IRC operator\r\n";
+    send(socket, message.c_str(), message.length(), 0);
+}
+
+

--- a/srcs/response.cpp
+++ b/srcs/response.cpp
@@ -143,3 +143,10 @@ void    send_user_quit_answer(int socket)
     std::string message = ":127.0.0.1 ERROR :user quitted the server\r\n";
     send(socket, message.c_str(), message.length(), 0);
 }
+
+void    send_no_privileges(int socket)
+{
+    std::string message = ":127.0.0.1 481 ERR_NOPRIVILEGES :Permission Denied- You're not an IRC operator\r\n";
+    send(socket, message.c_str(), message.length(), 0);
+}
+

--- a/srcs/response.hpp
+++ b/srcs/response.hpp
@@ -28,5 +28,6 @@ void    send_back_from_away_message(int socket);
 void    send_already_registred(int socket);
 void    send_user_joined_channel(int socket, std::string nickname, std::string username, std::string channel_name);
 void    send_user_quit_answer(int socket);
+void    send_no_privileges(int socket);
 
 #endif

--- a/srcs/response.hpp
+++ b/srcs/response.hpp
@@ -29,5 +29,6 @@ void    send_already_registred(int socket);
 void    send_user_joined_channel(int socket, std::string nickname, std::string username, std::string channel_name);
 void    send_user_quit_answer(int socket);
 void    send_no_privileges(int socket);
+void    send_youre_oper(int socket);
 
 #endif

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -65,7 +65,7 @@ bool    Server::exec(std::string *all, unsigned int i)
                 delete[] value;
                 continue;
             }
-            if (is_nickname_available(all_users, value[1]))
+            if (is_nickname_available(all_users, value[1]) && !is_banned_nickname(value[1], unavailable_nicknames))
                 all_users = set_user_nickname(all_users, i -1, value[1]);
             else
                 send_nickname_already_used(fds[i].fd, value[1]);
@@ -246,6 +246,7 @@ bool    Server::exec(std::string *all, unsigned int i)
                 return (true);
             }
             close(fds[user_to_kill->user_id + 1].fd);
+            unavailable_nicknames.push_back(user_to_kill->nickname);
             all_users = delete_user_from_list(user_to_kill->user_id, all_users);
             number_of_socket--;
         }

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -55,7 +55,9 @@ void    Server::update_fds_all_users(int user_id)
     {
         fds[i] = fds[i + 1];
         if (get_user(i, all_users))
+		{
             get_user(i, all_users)->user_id--;
+		}
     }
 }
 
@@ -241,6 +243,7 @@ bool    Server::exec(std::string *all, unsigned int i)
         if (value[0] == "KILL")
         {
             users *user_to_kill;
+            int update_at;
             if (value[1].empty() || value[2].empty())
             {
                 send_need_more_params(value[0], fds[i].fd);
@@ -256,11 +259,12 @@ bool    Server::exec(std::string *all, unsigned int i)
                 send_no_such_nick(fds[i].fd, value[1]);
                 return (true);
             }
+            update_at = user_to_kill->user_id;
             close(fds[user_to_kill->user_id + 1].fd);
             unavailable_nicknames.push_back(user_to_kill->nickname);
             all_users = delete_user_from_list(user_to_kill->user_id, all_users);
-            update_fds_all_users(i);
             number_of_socket--;
+            update_fds_all_users(update_at);
         }
         if (value[0] == "SHUTDOWN")
         {
@@ -272,8 +276,8 @@ bool    Server::exec(std::string *all, unsigned int i)
             send_user_quit_answer(fds[i].fd);
             all_users = delete_user_from_list(i - 1, all_users);
             close(fds[i].fd);
-            update_fds_all_users(i);
             number_of_socket--;
+            update_fds_all_users(i);
         }
         delete[] value;
     }

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -16,6 +16,7 @@
 #include "commands.hpp"
 #include "check.hpp"
 #include "channels.hpp"
+#include <vector>
 
 class Server {
     public:
@@ -33,6 +34,7 @@ class Server {
         int                 port;
         struct pollfd       fds[200];
         users               *all_users;
+        std::vector<std::string> unavailable_nicknames;
         channel             *channels;
         int                 number_of_socket;
 };

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -27,6 +27,7 @@ class Server {
         void    run(void);
         void    setup(void);
         bool    exec(std::string *all, unsigned int i);
+        void    update_fds_all_users(int user_id);
     private:
         struct sockaddr_in  address;
         int                 server_fd;

--- a/srcs/users.cpp
+++ b/srcs/users.cpp
@@ -190,6 +190,12 @@ users   *delete_user_from_list(int user_id, users *lst)
         {
             if (previous == NULL)
             {
+                if (tmp->next)
+                {
+                    users *next = tmp->next;
+                    delete tmp;
+                    return (next);
+                }
                 delete tmp;
                 return (NULL);
             }

--- a/srcs/users.cpp
+++ b/srcs/users.cpp
@@ -9,6 +9,7 @@ users   *new_user(int user_id, std::string nickname, std::string username)
     new_user->username = username;
     new_user->authentificate = false;
     new_user->connected = false;
+    new_user->is_operator = false;
     new_user->next = NULL;
     return (new_user);
 }

--- a/srcs/users.hpp
+++ b/srcs/users.hpp
@@ -2,6 +2,7 @@
 # define USER_HPP
 
 #include <iostream>
+#define DBG(vari) std::cerr<<#vari<<" = "<<(vari)<<std::endl;
 
 struct users {
     unsigned int    user_id;

--- a/srcs/users.hpp
+++ b/srcs/users.hpp
@@ -9,6 +9,7 @@ struct users {
     std::string     username;
     bool            authentificate;
     bool            connected;
+    bool            is_operator;
     bool            away;
     std::string     away_message;
     struct users    *next;

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -9,6 +9,11 @@ std::string *split(std::string to_split, std::string split_at)
     while (i < to_split.size())
     {
         pos = to_split.find(split_at);
+        if (pos == 0)
+        {
+            to_split.erase(0, 1);
+            continue ;
+        }
         if (pos > to_split.size())
         {
             token[i] = to_split.substr(0, to_split.size());


### PR DESCRIPTION
Le booléen `bool is_operator;` à été rajouté à la struct user pour déterminer si l'utilisateur à les droits nécessaires pour exécuter une certaine commande
Il peut maintenant y avoir plusieurs séparateurs d'affilée sans que ça pose problème pour le split
Le message pour le password est bien envoyé à l'utilisateur même si un autre est déjà connecté
Ajout des commandes KILL et OPER qui nécessiteront probablement des modifications
Ajout aussi d'un vector à la class server pour stocker la liste des nicknames interdits ajoutés par la commande KILL
Lorsqu'un utilisateur est déconnecté avec QUIT ou KILL, update des fds et de la liste des utilisateurs
