### PR TITLE
Update repo architecture 2

### DIFF
--- a/srcs/channels.cpp
+++ b/srcs/channels.cpp
@@ -98,7 +98,8 @@ int remove_user_from_channels(channel *channels, int user_id)
             for (; i < tmp->nb_users; ++i)
             {
                 tmp->users_id[i] = tmp->users_id[i + 1];
-                tmp->users_id[i]--; // Je décrémente tous les ids qui sont dans mon tableau d'int sinon ils ne s'actualisent pas avec update_fds_all_users()
+                if (tmp->users_id[i] != 0)
+                    tmp->users_id[i]--; // Je décrémente tous les ids qui sont dans mon tableau d'int sinon ils ne s'actualisent pas avec update_fds_all_users()
             }
             tmp->nb_users--;
         }

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -5,7 +5,6 @@ Server::Server(void)
     this->all_users = NULL;
     this->channels = NULL;
     this->number_of_socket = 1;
-	this->nfds = 1;
 }
 
 void    Server::set_config(int port, char *password)
@@ -272,7 +271,6 @@ bool    Server::exec_kill(std::string *value, unsigned int i, users *user)
     number_of_socket--;
     update_fds_all_users(update_at + 1);
     remove_user_from_channels(channels, update_at);
-    nfds--;
     return (false);
 }
 
@@ -290,7 +288,6 @@ void    Server::exec_quit(unsigned int i)
     number_of_socket--;
     update_fds_all_users(i);
     remove_user_from_channels(channels, i - 1);
-    nfds--;
 }
 
 bool    Server::exec(std::string *all, unsigned int i)
@@ -362,18 +359,17 @@ void    Server::run(void)
                     perror("accept");
                     exit(EXIT_FAILURE);
                 }
-                number_of_socket++;
                 all_users = add_user(all_users, new_user(socket_id, "", ""));
-                fds[nfds].fd = new_socket[socket_id];
-                fds[nfds].events = POLLIN;
-                send(fds[nfds].fd, "Chatting in : <#Inserer le bon channel>\n", strlen("Chatting in : <#Inserer le bon channel>\n"), 0);
-                nfds++;
+                fds[number_of_socket].fd = new_socket[socket_id];
+                fds[number_of_socket].events = POLLIN;
+                send(fds[number_of_socket].fd, "Chatting in : <#Inserer le bon channel>\n", strlen("Chatting in : <#Inserer le bon channel>\n"), 0);
+                number_of_socket++;
                 socket_id++;
             }
             else
             {
                 i = 0;
-                while (i < (unsigned int)nfds)
+                while (i < (unsigned int)number_of_socket)
                 {
                     throw_err_password = true;
                     i++;

--- a/srcs/server.hpp
+++ b/srcs/server.hpp
@@ -30,14 +30,14 @@ class Server {
         void    update_fds_all_users(int user_id);
 
         void    exec_pass(std::string *value, unsigned int i);
-        bool    exec_nick(std::string *value, unsigned int i);
-        bool    exec_user(std::string *value, unsigned int i);
-        bool    exec_msg(std::string *value, unsigned int i);
+        bool    exec_nick(std::string *value, unsigned int i, users *user);
+        bool    exec_user(std::string *value, unsigned int i, users *user);
+        bool    exec_msg(std::string *value, unsigned int i, users *user);
         void    exec_away(std::string *value, unsigned int i);
-        bool    exec_join(std::string *value, unsigned int i);
-        bool    exec_part(std::string *value, unsigned int i);
-        bool    exec_oper(std::string *value, unsigned int i);
-        bool    exec_kill(std::string *value, unsigned int i);
+        bool    exec_join(std::string *value, unsigned int i, users *user);
+        bool    exec_part(std::string *value, unsigned int i, users *user);
+        bool    exec_oper(std::string *value, unsigned int i, users *user);
+        bool    exec_kill(std::string *value, unsigned int i, users *user);
         bool    exec_shutdown(std::string *value);
         void    exec_quit(unsigned int i);
     private:


### PR DESCRIPTION
nfds remplacé par number_of_socket dans le server::run
Ajout d'une variable user temporaire dans le server::exec qui remplace `get_user(i -1, all_users)` pour plus de lisibilité
Fix remove_user_from_channels: quand l'user id valait 0 je décrémentais quand même son id ce qui était une erreur
