### PR TITLE
Fix remove user from channels

### DIFF
--- a/srcs/channels.cpp
+++ b/srcs/channels.cpp
@@ -11,7 +11,7 @@ bool	channel_exists(std::string name, channel *channels)
     {
         return (true);
     }
-    while (tmp->next)
+    while (tmp)
     {
         if (tmp->name == name)
         {

--- a/srcs/channels.cpp
+++ b/srcs/channels.cpp
@@ -92,19 +92,25 @@ int remove_user_from_channels(channel *channels, int user_id, pollfd *fds, std::
     while (tmp)
     {
         i = find_channel_user(tmp, user_id);
+        int tmp_id = tmp->users_id[i];
         if (i != -1)
         {
+            for (; i < tmp->nb_users; ++i)
+            {
+                tmp->users_id[i] = tmp->users_id[i + 1];
+            }
+            for (int j = 0; j < tmp->nb_users; j++)
+            {
+                if (tmp->users_id[j] != 0 && tmp->users_id[j] > tmp_id)
+                {
+                    tmp->users_id[j]--; // Je décrémente tous les ids qui sont dans mon tableau d'int sinon ils ne s'actualisent pas avec update_fds_all_users()
+                }
+            }
+            tmp->nb_users--;
             for (int it = 0; it < (tmp->nb_users); it++)
             {
                 send_user_part_channel(fds[tmp->users_id[it] + 1].fd, nickname, username, tmp->name, part_msg);
             }
-            for (; i < tmp->nb_users; ++i)
-            {
-                tmp->users_id[i] = tmp->users_id[i + 1];
-                if (tmp->users_id[i] != 0)
-                    tmp->users_id[i]--; // Je décrémente tous les ids qui sont dans mon tableau d'int sinon ils ne s'actualisent pas avec update_fds_all_users()
-            }
-            tmp->nb_users--;
         }
         tmp = tmp->next;
     }

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -125,7 +125,7 @@ bool    Server::exec_msg(std::string *value, unsigned int i, users *user)
             {
                 std::cout << "sending message to: " << get_user(chan->users_id[it], all_users)->nickname << std::endl;
                 send_message_to_user(
-                    new_socket[get_user(chan->users_id[it], all_users)->user_id],
+                    fds[chan->users_id[it] + 1].fd,
                     value[1],
                     value[2],
                     user,
@@ -245,7 +245,6 @@ bool    Server::exec_part(std::string *value, unsigned int i, users *user)
     for (int i = u; i < chan->nb_users; ++i)
         chan->users_id[i] = chan->users_id[i + 1];
     chan->nb_users--;
-    send_not_on_channel(chan->name, fds[i].fd);
     return (true);
 }
 
@@ -307,13 +306,14 @@ void    Server::exec_quit(unsigned int i, users *user)
 {
     std::string nick = user->nickname;
     std::string username = user->username;
+    int         user_id = get_user(i - 1, all_users)->user_id;
 
     send_user_quit_answer(fds[i].fd);
     all_users = delete_user_from_list(i - 1, all_users);
     close(fds[i].fd);
     number_of_socket--;
     update_fds_all_users(i);
-    remove_user_from_channels(channels, i - 1, fds, nick, username, "QUIT");
+    remove_user_from_channels(channels, user_id, fds, nick, username, "QUIT");
 }
 
 void    Server::exec_kick(std::string *value, unsigned int i)
@@ -355,8 +355,8 @@ bool    Server::exec(std::string *all, unsigned int i)
             if (exec_user(value, i, user))
                 continue;
         if (value[0] == "PRIVMSG" || value[0] == "NOTICE")
-            if (exec_msg(value, i, user))
-                continue;
+            exec_msg(value, i, user);
+                // continue;
         if (value[0] == "AWAY")
             exec_away(value, i);
         if (value[0] == "JOIN")

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -420,11 +420,10 @@ void    Server::run(void)
             }
             else
             {
-                i = 0;
+                i = 1;
                 while (i < (unsigned int)number_of_socket)
                 {
                     throw_err_password = true;
-                    i++;
                     if (fds[i].revents == 1)
                     {
                         std::string *all = get_commands(fds, i);
@@ -446,6 +445,7 @@ void    Server::run(void)
                         }
                         delete[] all;
                     }
+                    i++;
                 }
             }
         }

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -242,6 +242,10 @@ bool    Server::exec_part(std::string *value, unsigned int i, users *user)
                 ""
             );
     }
+    if (!value[2].empty() && find_user_by_nickname(value[2], all_users))
+        send_not_on_channel(chan->name, new_socket[find_user_by_nickname(value[2], all_users)->user_id]);
+    else
+        send_not_on_channel(chan->name, fds[i].fd);
     for (int i = u; i < chan->nb_users; ++i)
         chan->users_id[i] = chan->users_id[i + 1];
     chan->nb_users--;
@@ -337,7 +341,7 @@ void    Server::exec_kick(std::string *value, unsigned int i)
     else
     {
         exec_part(value, find_user_by_nickname(value[2], all_users)->user_id + 1, find_user_by_nickname(value[2], all_users));
-    } 
+    }
 }
 
 bool    Server::exec(std::string *all, unsigned int i)

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -174,13 +174,11 @@ bool    Server::exec_join(std::string *value, unsigned int i, users *user)
         chan = create_channel(value[1], "Default Topic");
         chan->users_id[chan->nb_users] = user->user_id;
         chan->nb_users++;
-        display_channel_users(chan);
         channels = add_new_channel(channels, chan);
     }
     else
     {
         chan = find_channel(value[1], channels);
-        display_channel_users(chan);
         if (find_channel_user(chan, user->user_id) != -1)
         {
             std::cout << "L'utilisateur est déjà membre du channel...\n"; // Que renvoyer ?
@@ -188,7 +186,6 @@ bool    Server::exec_join(std::string *value, unsigned int i, users *user)
         }
         chan->users_id[chan->nb_users] = user->user_id;
         chan->nb_users++;
-        display_channel_users(chan);
 
         for (int it = 0; it < (chan->nb_users); it++)
         {

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -355,8 +355,8 @@ bool    Server::exec(std::string *all, unsigned int i)
             if (exec_user(value, i, user))
                 continue;
         if (value[0] == "PRIVMSG" || value[0] == "NOTICE")
-            exec_msg(value, i, user);
-                // continue;
+            if (exec_msg(value, i, user))
+                continue;
         if (value[0] == "AWAY")
             exec_away(value, i);
         if (value[0] == "JOIN")

--- a/srcs/server.cpp
+++ b/srcs/server.cpp
@@ -174,11 +174,13 @@ bool    Server::exec_join(std::string *value, unsigned int i, users *user)
         chan = create_channel(value[1], "Default Topic");
         chan->users_id[chan->nb_users] = user->user_id;
         chan->nb_users++;
+        display_channel_users(chan);
         channels = add_new_channel(channels, chan);
     }
     else
     {
         chan = find_channel(value[1], channels);
+        display_channel_users(chan);
         if (find_channel_user(chan, user->user_id) != -1)
         {
             std::cout << "L'utilisateur est déjà membre du channel...\n"; // Que renvoyer ?
@@ -186,6 +188,7 @@ bool    Server::exec_join(std::string *value, unsigned int i, users *user)
         }
         chan->users_id[chan->nb_users] = user->user_id;
         chan->nb_users++;
+        display_channel_users(chan);
 
         for (int it = 0; it < (chan->nb_users); it++)
         {


### PR DESCRIPTION
Fix `remove_user_from_channels`: j'oubliais de décrémenter également tous les user_ids avant la position de celui à enlever de l'array s'ils sont supérieurs à l'user_id à enlever)

Fix dans le `server::run` pour l'issue #78 : s'il n'y a qu'un utilisateur, i vaut 1 au premier tour de boucle, il y a 2 pollfd dans fds (server et le user) ça passe donc la condition `while (i < (unsigned int)number_of_socket)`, i vaut maintenant 2 et ça va cherche fds[2] qui n'existe pas et ça segfault. J'ai mis i à 1 et je l'ai incrémenté en fin de boucle pour éviter ça

Fix `channel_exists`: modif de la condition du while qui n'était pas correcte